### PR TITLE
Fix for unable to detect face for MKV video format on LTX Prepare Dataset

### DIFF
--- a/nodes/ltxv_prepare_dataset/__init__.py
+++ b/nodes/ltxv_prepare_dataset/__init__.py
@@ -179,6 +179,9 @@ class RSLTXVPrepareDataset:
                 "char_positions_required": (["10%", "25%", "50%", "75%", "100%"], {"default": "75%", "tooltip": "Fraction of sample positions that must contain ANY named character. Scales with sample_count (e.g. 75% of 4 = 3, 75% of 8 = 6). Any mix of named characters across positions counts — they don't need to be the same character."}),
                 "allow_unknown_faces_in": (["0%", "10%", "25%", "50%", "75%", "100%"], {"default": "25%", "tooltip": "Fraction of sample positions allowed to contain unknown (non-reference) faces. Scales with sample_count (e.g. 25% of 4 = 1 position, 25% of 8 = 2). 0% = reject any extras at all, 100% = allow extras anywhere. 25% (default) tolerates one detection blip in a 4-sample chunk."}),
                 "clip_check": ("BOOLEAN", {"default": False, "tooltip": "When ON, re-scan every existing clip in the dataset and rewrite its `characters` field based on current character refs. Useful when you've added a new reference character after the dataset was already partly built — existing clips that contain the new character get their characters list updated. Runs once at the start of the run; leave OFF for subsequent runs."}),
+                "skip_phase_1_mine": ("BOOLEAN", {"default": False, "tooltip": "Skip Phase 1 (clip mining / face detection / extraction). Phase 0 reconciliation still runs against on-disk clips, then jumps straight to captioning/encoding using whatever's already in <output>/clips/. Use when clips are pre-made and only captions+encodes are missing."}),
+                "skip_phase_2_caption": ("BOOLEAN", {"default": False, "tooltip": "Skip Phase 2 (Ollama captioning + LLM QC). Entries without captions stay uncaptioned. Use when you'll caption manually or have already written captions into dataset.json."}),
+                "skip_phase_3_encode": ("BOOLEAN", {"default": False, "tooltip": "Skip Phase 3 (text / video / audio latent encoding + subprocess fallback). Use to stop after mining+captioning, e.g. when encoding will run later on a different machine."}),
                 "conditioning_folder": ("STRING", {"default": "", "tooltip": "IC-LoRA: folder of conditioning input videos (depth maps, edge maps, poses). Matched to media_folder by filename. Media folder is the ground truth output."}),
                 "clip": ("CLIP", {"tooltip": "Text encoder (from CheckpointLoaderSimple). When connected, encodes captions in-process instead of slow subprocess."}),
                 "vae": ("VAE", {"tooltip": "Video VAE (from CheckpointLoaderSimple). When connected, encodes video latents in-process instead of slow subprocess."}),
@@ -247,6 +250,9 @@ class RSLTXVPrepareDataset:
         clip_vision=None,
         target_fps: float = 0.0,
         max_samples: int = 0,
+        skip_phase_1_mine: bool = False,
+        skip_phase_2_caption: bool = False,
+        skip_phase_3_encode: bool = False,
         unique_id=None,
     ):
         validate_submodule()
@@ -927,8 +933,17 @@ class RSLTXVPrepareDataset:
         # nearly complete. Encoded artifacts are the source of truth;
         # don't mine to satisfy a JSON-derived quota when the artifacts
         # already exist.
-        if (max_samples > 0 and len(existing_entries) >= max_samples) or skip_mining:
-            if skip_mining:
+        if (
+            (max_samples > 0 and len(existing_entries) >= max_samples)
+            or skip_mining
+            or skip_phase_1_mine
+        ):
+            if skip_phase_1_mine:
+                logger.info(
+                    "Skipping Phase 1 (mining) — skip_phase_1_mine=True. "
+                    "Will use clips already present in clips/ as-is."
+                )
+            elif skip_mining:
                 logger.info(
                     "Skipping mining: no new source media. Will only fix "
                     "missing encodes on existing clips (if any). "
@@ -1665,67 +1680,83 @@ class RSLTXVPrepareDataset:
         character_refs = None  # noqa: F841
         location_refs = None  # noqa: F841
         clip_vision = None  # noqa: F841
-        try:
-            import comfy.model_management as mm
-            mm.unload_all_models()
-            if hasattr(mm, "cleanup_models"):
-                try:
-                    mm.cleanup_models(keep_clone_weights_loaded=False)
-                except TypeError:
-                    mm.cleanup_models()
-            if hasattr(mm, "current_loaded_models"):
-                try:
-                    mm.current_loaded_models.clear()
-                except Exception:
-                    pass
-            mm.soft_empty_cache()
-            gc.collect()
-            mm.free_memory(1e18, mm.get_torch_device())
-            logger.info("Cleared ComfyUI VRAM before Ollama captioning phase")
-        except Exception as e:
-            logger.warning(f"Could not fully free VRAM before captioning: {e}")
 
-        captioning.caption_dataset_json(
-            dataset_json_path, clip_paths, caption_mode, lora_trigger,
-            ollama_url=ollama_url, ollama_model=ollama_model,
-            target_face_b64=target_face_b64, caption_style=caption_style,
-            cast_names=cast_names, cast_refs=cast_refs,
-            location_refs=location_refs_list,
-            skip_id_pass=skip_id_pass,
-        )
+        if skip_phase_2_caption:
+            logger.info(
+                "Skipping Phase 2 (Ollama captioning) — skip_phase_2_caption=True. "
+                "Entries with empty captions remain uncaptioned."
+            )
+        else:
+            try:
+                import comfy.model_management as mm
+                mm.unload_all_models()
+                if hasattr(mm, "cleanup_models"):
+                    try:
+                        mm.cleanup_models(keep_clone_weights_loaded=False)
+                    except TypeError:
+                        mm.cleanup_models()
+                if hasattr(mm, "current_loaded_models"):
+                    try:
+                        mm.current_loaded_models.clear()
+                    except Exception:
+                        pass
+                mm.soft_empty_cache()
+                gc.collect()
+                mm.free_memory(1e18, mm.get_torch_device())
+                logger.info("Cleared ComfyUI VRAM before Ollama captioning phase")
+            except Exception as e:
+                logger.warning(f"Could not fully free VRAM before captioning: {e}")
 
-        # Post-captioning quota check. If clips got rejected (MISMATCH face
-        # QC, or length-overshoot caption rejection) and the chunk pool
-        # still has unused candidates, the dataset is now under quota.
-        # Automatic re-mining is non-trivial because mining state is
-        # interleaved with character-mode setup throughout prepare(); for
-        # now we surface a clear warning so the user knows to re-run
-        # prepare_dataset, which will resume from the persisted chunk_pool
-        # and fill the gap. See Reference/dataset-self-heal-spec.md for
-        # the deferred auto-remine plan.
-        try:
-            with open(dataset_json_path) as _qf:
-                _post_cap_entries = json.load(_qf)
-        except (OSError, json.JSONDecodeError):
-            _post_cap_entries = []
-        _pool_remaining = pool_state.get("remaining", 0)
-        if max_samples > 0 and len(_post_cap_entries) < max_samples:
-            shortfall = max_samples - len(_post_cap_entries)
-            if _pool_remaining > 0:
-                logger.warning(
-                    f"Post-caption quota check: {len(_post_cap_entries)}/{max_samples} "
-                    f"samples (short by {shortfall}). chunk_pool has "
-                    f"{_pool_remaining} clips remaining — re-run prepare_dataset "
-                    f"to mine replacements for the rejected clips."
-                )
-            else:
-                logger.warning(
-                    f"Post-caption quota check: {len(_post_cap_entries)}/{max_samples} "
-                    f"samples (short by {shortfall}). chunk_pool is empty — "
-                    f"add more source media to fill the remaining slots."
-                )
+            captioning.caption_dataset_json(
+                dataset_json_path, clip_paths, caption_mode, lora_trigger,
+                ollama_url=ollama_url, ollama_model=ollama_model,
+                target_face_b64=target_face_b64, caption_style=caption_style,
+                cast_names=cast_names, cast_refs=cast_refs,
+                location_refs=location_refs_list,
+                skip_id_pass=skip_id_pass,
+            )
+
+            # Post-captioning quota check. If clips got rejected (MISMATCH face
+            # QC, or length-overshoot caption rejection) and the chunk pool
+            # still has unused candidates, the dataset is now under quota.
+            # Automatic re-mining is non-trivial because mining state is
+            # interleaved with character-mode setup throughout prepare(); for
+            # now we surface a clear warning so the user knows to re-run
+            # prepare_dataset, which will resume from the persisted chunk_pool
+            # and fill the gap. See Reference/dataset-self-heal-spec.md for
+            # the deferred auto-remine plan.
+            try:
+                with open(dataset_json_path) as _qf:
+                    _post_cap_entries = json.load(_qf)
+            except (OSError, json.JSONDecodeError):
+                _post_cap_entries = []
+            _pool_remaining = pool_state.get("remaining", 0)
+            if max_samples > 0 and len(_post_cap_entries) < max_samples:
+                shortfall = max_samples - len(_post_cap_entries)
+                if _pool_remaining > 0:
+                    logger.warning(
+                        f"Post-caption quota check: {len(_post_cap_entries)}/{max_samples} "
+                        f"samples (short by {shortfall}). chunk_pool has "
+                        f"{_pool_remaining} clips remaining — re-run prepare_dataset "
+                        f"to mine replacements for the rejected clips."
+                    )
+                else:
+                    logger.warning(
+                        f"Post-caption quota check: {len(_post_cap_entries)}/{max_samples} "
+                        f"samples (short by {shortfall}). chunk_pool is empty — "
+                        f"add more source media to fill the remaining slots."
+                    )
 
         # ===== PHASE 3: ENCODE CONDITIONS AND LATENTS =====
+        if skip_phase_3_encode:
+            logger.info(
+                "Skipping Phase 3 (text/video/audio latent encoding) — "
+                "skip_phase_3_encode=True. Clips and dataset.json are ready; "
+                "encode separately when needed."
+            )
+            _unload_all_prepper_models()
+            return (str(output_dir), str(dataset_json_path))
+
         # Reload entries from JSON — captioning may have rejected some clips,
         # and existing_entries in memory still has the pre-rejection list.
         with open(dataset_json_path) as f:

--- a/nodes/ltxv_prepare_dataset/captioning.py
+++ b/nodes/ltxv_prepare_dataset/captioning.py
@@ -1269,9 +1269,15 @@ def caption_dataset_json(
             )
 
             if prep is None:
-                # MISMATCH — reject this entry
+                # MISMATCH — reject this entry and purge on-disk artifacts
+                # (clip + latents/conditions/audio_latents) so the failed
+                # match can't be silently re-introduced on a later run
+                # via the artifact-trumps-JSON guard.
                 logger.info(f"  LLM QC: MISMATCH — removing {vf.name}")
-                reject_entry(i, entries, dataset_json_path, "llm_mismatch")
+                reject_entry(
+                    i, entries, dataset_json_path,
+                    "llm_mismatch", purge_artifacts=True,
+                )
                 removed_count += 1
                 continue
 

--- a/nodes/ltxv_prepare_dataset/face.py
+++ b/nodes/ltxv_prepare_dataset/face.py
@@ -38,7 +38,13 @@ _FACE_MATCH_THRESHOLD = 0.40  # Cosine similarity threshold for face matching (l
 _FACE_DET_MIN_CONFIDENCE = 0.5
 _FACE_UNKNOWN_MIN_CONFIDENCE = 0.85
 
-_last_analysis_frame_id: int | None = None
+# Cache the actual frame (strong ref), not id(frame): CPython recycles
+# object ids immediately once an array is freed, so a freshly-decoded
+# video frame can land at the same heap slot a reference image just
+# vacated, hit a stale cache, and return faces whose bboxes don't exist
+# in the new frame — observed as "no face detected" until the address
+# happens to differ.
+_last_analysis_frame: "np.ndarray | None" = None
 _last_analysis_faces: list = []
 
 
@@ -86,13 +92,13 @@ def analyze_frame(frame: np.ndarray) -> list:
     """Run InsightFace on frame; memoize by id(frame) so repeat calls are
     free. Drops low-confidence detections (cactus/tiki/poster/cartoon
     patterns) so they don't pollute hit counts or unknown-face counts."""
-    global _last_analysis_frame_id, _last_analysis_faces
+    global _last_analysis_frame, _last_analysis_faces
     app = get_face_app()
     if app is None:
-        _last_analysis_frame_id = id(frame)
+        _last_analysis_frame = frame
         _last_analysis_faces = []
         return []
-    if id(frame) == _last_analysis_frame_id:
+    if frame is _last_analysis_frame:
         return _last_analysis_faces
     raw = app.get(frame)
     # Filter by detector confidence — non-human face-like patterns
@@ -101,7 +107,7 @@ def analyze_frame(frame: np.ndarray) -> list:
         f for f in raw
         if float(getattr(f, "det_score", 1.0)) >= _FACE_DET_MIN_CONFIDENCE
     ]
-    _last_analysis_frame_id = id(frame)
+    _last_analysis_frame = frame
     _last_analysis_faces = faces
     return faces
 
@@ -289,7 +295,7 @@ def unload_face_models() -> list[str]:
     Safe to call even if nothing was loaded.
     """
     global _face_app, _face_app_checked
-    global _last_analysis_frame_id, _last_analysis_faces
+    global _last_analysis_frame, _last_analysis_faces
 
     freed: list[str] = []
     if _face_app is not None:
@@ -302,7 +308,7 @@ def unload_face_models() -> list[str]:
         freed.append("InsightFace")
 
     # Drop frame memoization (holds a reference to the most recent frame)
-    _last_analysis_frame_id = None
+    _last_analysis_frame = None
     _last_analysis_faces = []
 
     return freed

--- a/nodes/ltxv_train_lora.py
+++ b/nodes/ltxv_train_lora.py
@@ -160,6 +160,7 @@ class RSLTXVTrainLoRA:
                 "lr_cycle_decay":         ("FLOAT", {"default": 1.0, "min": 0.1, "max": 1.0, "step": 0.01,
                                                      "tooltip": "Multiply LR by this factor each cycle reset. 1.0 = no decay, 0.8 = 20% reduction per cycle."}),
                 "gradient_checkpointing": ("BOOLEAN", {"default": True}),
+                "layer_offloading":       ("BOOLEAN", {"default": True, "tooltip": "Stream transformer blocks CPU↔GPU one at a time. Saves ~10× VRAM but is much slower (PCIe-bound). Turn OFF if you have headroom (24GB+ recommended for off; 16GB may fit with fp8+gc — try off first, flip back on if OOM)."}),
                 "ffn_chunks":             ("INT",     {"default": 0, "min": 0, "max": 16, "step": 1, "tooltip": "Split FFN layers into N chunks along sequence dim to reduce peak VRAM. 0 = disabled, 4 = good default. Trades speed for memory."}),
                 # Quantization
                 "quantization": (["fp8-quanto", "int8-quanto", "int4-quanto", "none"], {"default": "fp8-quanto", "tooltip": "fp8 recommended (no C++ build tools needed). int4/int2 require 'pip install ninja' + C++ compiler."}),
@@ -257,6 +258,7 @@ class RSLTXVTrainLoRA:
         lr_cycle_steps: int = 0,
         lr_cycle_decay: float = 1.0,
         gradient_checkpointing: bool = True,
+        layer_offloading: bool = True,
         ffn_chunks: int = 0,
         quantization: str = "fp8-quanto",
         strategy: str = "text_to_video",
@@ -559,7 +561,7 @@ class RSLTXVTrainLoRA:
             vocoder=vocoder,
             seed=42,
             resume_checkpoint=self._find_latest_checkpoint(output_dir) if resume else "",
-            layer_offloading=True,
+            layer_offloading=layer_offloading,
             node_id=str(unique_id) if unique_id is not None else "",
             ffn_chunks=ffn_chunks,
         )

--- a/nodes/ltxv_train_lora.py
+++ b/nodes/ltxv_train_lora.py
@@ -340,6 +340,39 @@ class RSLTXVTrainLoRA:
 
         # ---- Step 2: load EmbeddingsProcessor from checkpoint ----
         logger.info("Loading EmbeddingsProcessor from checkpoint...")
+
+        # === TEMP DEBUG: confirm what loader code + metadata are reaching us ===
+        import json as _json
+        import os as _os
+        from safetensors import safe_open as _safe_open
+        import ltx_core, ltx_trainer, safetensors as _st
+        from ltx_core.text_encoders.gemma import embeddings_connector as _ec
+        from ltx_core.text_encoders.gemma.encoders import encoder_configurator as _confg
+        from ltx_core.loader.sft_loader import SafetensorsModelStateDictLoader as _Sfl
+        logger.info(f"[DEBUG] model_full_path = {model_full_path}")
+        logger.info(f"[DEBUG] file size MB = {_os.path.getsize(model_full_path) / (1024*1024):.1f}")
+        logger.info(f"[DEBUG] safetensors version = {_st.__version__}")
+        logger.info(f"[DEBUG] ltx_core from: {ltx_core.__file__}")
+        logger.info(f"[DEBUG] ltx_trainer from: {ltx_trainer.__file__}")
+        logger.info(f"[DEBUG] embeddings_connector from: {_ec.__file__}")
+        logger.info(f"[DEBUG] encoder_configurator from: {_confg.__file__}")
+        with _safe_open(model_full_path, framework="pt", device="cpu") as _f:
+            _meta = _f.metadata()
+        logger.info(f"[DEBUG] safetensors metadata keys: {list(_meta.keys()) if _meta else 'NONE'}")
+        if _meta and "config" in _meta:
+            _cfg = _json.loads(_meta["config"])
+            _t = _cfg.get("transformer", {})
+            logger.info(f"[DEBUG] transformer keys count: {len(_t)}")
+            for _k in ("connector_num_layers", "connector_num_attention_heads",
+                       "connector_attention_head_dim", "audio_connector_num_attention_heads",
+                       "caption_proj_before_connector", "connector_apply_gated_attention"):
+                logger.info(f"[DEBUG]   transformer[{_k}] = {_t.get(_k, '<MISSING>')}")
+        # also: what does the SDLoader's metadata() return?
+        _via_loader = _Sfl().metadata(model_full_path)
+        logger.info(f"[DEBUG] SDLoader.metadata() top keys: {list(_via_loader.keys()) if _via_loader else 'EMPTY'}")
+        logger.info(f"[DEBUG] SDLoader.metadata().transformer count: {len(_via_loader.get('transformer', {})) if _via_loader else 0}")
+        # === END TEMP DEBUG ===
+
         from ltx_trainer.model_loader import load_embeddings_processor
         embeddings_processor = load_embeddings_processor(
             checkpoint_path=model_full_path,

--- a/nodes/ltxv_train_lora.py
+++ b/nodes/ltxv_train_lora.py
@@ -341,37 +341,26 @@ class RSLTXVTrainLoRA:
         # ---- Step 2: load EmbeddingsProcessor from checkpoint ----
         logger.info("Loading EmbeddingsProcessor from checkpoint...")
 
-        # === TEMP DEBUG: confirm what loader code + metadata are reaching us ===
-        import json as _json
-        import os as _os
+        # Sanity check: the EmbeddingsProcessor configurator reads its layer
+        # count + dims from the safetensors `config.transformer` section. If
+        # the user accidentally points `model_path` at an audio VAE / vocoder
+        # / VAE-only checkpoint, that section is missing, the model gets
+        # built with defaults (V1 19B-style 2-block), no state-dict keys
+        # match, and every param stays on the meta device — surfacing later
+        # as a confusing "Cannot copy out of meta tensor" at `.to(device)`.
+        # Catch it here with a clear error.
         from safetensors import safe_open as _safe_open
-        import ltx_core, ltx_trainer, safetensors as _st
-        from ltx_core.text_encoders.gemma import embeddings_connector as _ec
-        from ltx_core.text_encoders.gemma.encoders import encoder_configurator as _confg
-        from ltx_core.loader.sft_loader import SafetensorsModelStateDictLoader as _Sfl
-        logger.info(f"[DEBUG] model_full_path = {model_full_path}")
-        logger.info(f"[DEBUG] file size MB = {_os.path.getsize(model_full_path) / (1024*1024):.1f}")
-        logger.info(f"[DEBUG] safetensors version = {_st.__version__}")
-        logger.info(f"[DEBUG] ltx_core from: {ltx_core.__file__}")
-        logger.info(f"[DEBUG] ltx_trainer from: {ltx_trainer.__file__}")
-        logger.info(f"[DEBUG] embeddings_connector from: {_ec.__file__}")
-        logger.info(f"[DEBUG] encoder_configurator from: {_confg.__file__}")
+        import json as _json
         with _safe_open(model_full_path, framework="pt", device="cpu") as _f:
-            _meta = _f.metadata()
-        logger.info(f"[DEBUG] safetensors metadata keys: {list(_meta.keys()) if _meta else 'NONE'}")
-        if _meta and "config" in _meta:
-            _cfg = _json.loads(_meta["config"])
-            _t = _cfg.get("transformer", {})
-            logger.info(f"[DEBUG] transformer keys count: {len(_t)}")
-            for _k in ("connector_num_layers", "connector_num_attention_heads",
-                       "connector_attention_head_dim", "audio_connector_num_attention_heads",
-                       "caption_proj_before_connector", "connector_apply_gated_attention"):
-                logger.info(f"[DEBUG]   transformer[{_k}] = {_t.get(_k, '<MISSING>')}")
-        # also: what does the SDLoader's metadata() return?
-        _via_loader = _Sfl().metadata(model_full_path)
-        logger.info(f"[DEBUG] SDLoader.metadata() top keys: {list(_via_loader.keys()) if _via_loader else 'EMPTY'}")
-        logger.info(f"[DEBUG] SDLoader.metadata().transformer count: {len(_via_loader.get('transformer', {})) if _via_loader else 0}")
-        # === END TEMP DEBUG ===
+            _meta = _f.metadata() or {}
+        _cfg = _json.loads(_meta["config"]) if "config" in _meta else {}
+        if not _cfg.get("transformer"):
+            raise ValueError(
+                f"`model_path` points at '{Path(model_full_path).name}', which has no "
+                f"transformer config in its safetensors metadata. This is likely a VAE / "
+                f"audio_vae / vocoder checkpoint, not a full LTX-2 model. Pick a checkpoint "
+                f"like ltx-2-19b-dev.safetensors or ltx-2.3-22b-dev-fp8.safetensors."
+            )
 
         from ltx_trainer.model_loader import load_embeddings_processor
         embeddings_processor = load_embeddings_processor(

--- a/utils/ltxv_inprocess_trainer.py
+++ b/utils/ltxv_inprocess_trainer.py
@@ -1257,6 +1257,16 @@ class InProcessTrainer:
         else:
             x = x.requires_grad_(True)
 
+        # Cast latent inputs to bf16. fp8-marlin GEMM kernels (used when
+        # `quantization` is set) only accept bfloat16/float16 activations
+        # and otherwise raise "fp8_marlin_gemm only supports bfloat16 and
+        # float16". Targets stay in their original dtype so the loss is
+        # computed at higher precision.
+        if isinstance(x, list):
+            x = [t.to(dtype=torch.bfloat16) for t in x]
+        else:
+            x = x.to(dtype=torch.bfloat16)
+
         # ---- 3. Forward through ComfyUI model ----
         # inference_mode is already exited at the top level (ltxv_train_lora.py).
         pred = self._transformer(

--- a/utils/ltxv_inprocess_trainer.py
+++ b/utils/ltxv_inprocess_trainer.py
@@ -282,6 +282,9 @@ class InProcessTrainer:
             logger.info("Setting up layer offloading (blocks stream CPU↔GPU one at a time)...")
             self._transformer.train()
             setup_layer_offloading(self._transformer, device)
+            print(f"DEBUG: ep params={sum(1 for _ in self._embeddings_processor.parameters())}, "
+                f"on_meta={sum(1 for p in self._embeddings_processor.parameters() if str(p.device)=='meta')}, "
+                f"first_meta_name={next((n for n,p in self._embeddings_processor.named_parameters() if str(p.device)=='meta'), None)}")
             self._embeddings_processor.to(device)
             self._embeddings_processor.eval()
         else:


### PR DESCRIPTION
replaced the unsafe id(frame) memoization with a strong reference (_last_analysis_frame) and an is-comparison

1. Your reference image flows through compute_target_embedding → analyze_frame first, populating the cache with bboxes from the reference frame.
2. That reference ndarray is a local var; once the function returns, it can be freed and its Python object id is eligible for reuse.
3. When the mining loop reads a video frame, Python's allocator may hand back the same id to the new ndarray. analyze_frame then takes the cache shortcut and returns the reference image's detection. The reference's bbox doesn't correspond to anything in the video frame, so get_face_embedding's IoU lookup fails → match_characters_in_frame returns nothing → "no face detected".
4. Whether that id collision happens consistently is allocator/codec-path dependent. That's plausibly why MP4 worked for you but MKV didn't.